### PR TITLE
Update OLEDDisplay.java

### DIFF
--- a/src/main/java/de/pi3g/pi/oled/OLEDDisplay.java
+++ b/src/main/java/de/pi3g/pi/oled/OLEDDisplay.java
@@ -291,7 +291,7 @@ public class OLEDDisplay {
         for (int posY = 0; posY < DISPLAY_HEIGHT; posY++) {
             for (int posX = 0; posX < DISPLAY_WIDTH / 8; posX++) {
                 for (int bit = 0; bit < 8; bit++) {
-                    pixelval = (byte) ((pixels[index/8] >>  (8 - bit)) & 0x01);
+                    pixelval = (byte) ((pixels[index/8] >>  (7 - bit)) & 0x01);
                     setPixel(posX * 8 + bit, posY, pixelval > 0);
                     index++;
                 }


### PR DESCRIPTION
there was a bug in this file, that some bits were incorrectly readed from the image. This fix makes it work as it should.